### PR TITLE
Finish adding ocamlformat: add missing parameter

### DIFF
--- a/src/bin/server/command/getFormatted.ts
+++ b/src/bin/server/command/getFormatted.ts
@@ -9,7 +9,7 @@ export async function ocamlformat(session: Session, doc: LSP.TextDocument, range
     return null;
   }
   const text = doc.getText();
-  const ocamlformat = new processes.Ocamlformat(session, ["-"]).process;
+  const ocamlformat = new processes.Ocamlformat(session, ["--name", doc.uri, "-"]).process;
   ocamlformat.stdin.write(text);
   ocamlformat.stdin.end();
   const otxt = await new Promise<null | string>(resolve => {


### PR DESCRIPTION
@ELLIOTTCABLE I think the only thing needed to make your [PR](https://github.com/freebroccolo/ocaml-language-server/pull/133) work, was adding the missing `--name` parameter, which `ocamlformat` requires if piping to `stdin`.